### PR TITLE
go.mod: Require 1.20 minimum

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prashantv/clock
 
-go 1.21.1
+go 1.20
 
 require github.com/stretchr/testify v1.8.4
 


### PR DESCRIPTION
No reason to limit support to 1.21 right now.
There doesn't appear to be anything specific to 1.21 being used.
