### PR TITLE
ci: Set up testing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ["1.20.x", "1.21.x"]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go }}
+        cache: true
+    - name: Download dependencies
+      run: go mod download
+    - name: Test
+      run: make cover
+    - name: Upload coverage
+      uses: codecov/codecov-action@v3

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+SHELL = /bin/bash
+
+PROJECT_ROOT = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# Setting GOBIN and PATH ensures two things:
+# - All 'go install' commands we run
+#   only affect the current directory.
+# - All installed tools are available on PATH
+#   for commands like go generate.
+# This makes it easy for tools dependencies to be installed locally as needed.
+export GOBIN = $(PROJECT_ROOT)/bin
+export PATH := $(GOBIN):$(PATH)
+
+TEST_FLAGS ?= -v -race
+
+.PHONY: all
+all: lint test
+
+.PHONY: lint
+lint: tidy-lint
+
+.PHONY: tidy
+tidy:
+	go mod tidy
+
+.PHONY: tidy-lint
+tidy-lint:
+	@echo "[lint] Checking go mod tidy"
+	@go mod tidy && \
+		git diff --exit-code -- go.mod go.sum || \
+		(echo "[$(mod)] go mod tidy changed files" && false)
+
+.PHONY: test
+test:
+	go test $(TEST_FLAGS) ./...
+
+.PHONY: cover
+cover:
+	go test $(TEST_FLAGS) -coverprofile=cover.out -coverpkg=./... ./...
+	go tool cover -html=cover.out -o cover.html


### PR DESCRIPTION
Sets up a basic minimal CI.

- Test against Go 1.20 and 1.21 (depends on #3)
- Periodically check for outdated GitHub Actions
  - Do NOT check for outdated dependencies;
    minimum version selection means that
    we shouldn't bump the minimum required version of a dependency
    until we specifically need something from it.

Does not set up linting yet.
